### PR TITLE
.github: workflows: Remove unsupported Python version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,8 +14,6 @@ jobs:
         target:
           - scobc-a1-bootloader
         python-version:
-          - '3.10'
-          - '3.11'
           - '3.12'
           - '3.13'
         os:


### PR DESCRIPTION
From 043bb58 in Zephyr upstream, the minimum supported version of  Python has been updated from 3.10 to 3.12.
Therefore, remove Python 3.10 and 3.11 from our build tests.
