### PR TITLE
overlay:fix SPI NOR flash size unit

### DIFF
--- a/app.overlay
+++ b/app.overlay
@@ -25,7 +25,7 @@
 			s25fl256l0: s25fl256l0@0 {
 				compatible = "jedec,spi-nor";
 				reg = <0>;
-				size = <DT_SIZE_M(32)>;
+				size = <DT_SIZE_M(256)>;
 				spi-max-frequency = <12000000>;
 				status = "okay";
 				enter-4byte-addr = <1>;


### PR DESCRIPTION
This PR fixes the declared capacity of the external QSPI NOR flash S25FL256L0 in the SC-OBC A1 device tree.

The `size` property in the `jedec,spi-nor` binding expects the flash capacity in *Mbits*, not in MiB.

The S25FL256L0 device is a 256 Mbit flash (32 MiB), but the DTS was incorrectly using `<32>`, which Zephyr interpreted as 32 Mbit (4 MiB).

Update the `size` property from `<32>` to `<256>` to match the datasheet and binding requirements.

See the documentation here : 
https://docs.zephyrproject.org/latest/build/dts/api/bindings/mtd/jedec%2Cspi-nor.html#std-dtcompatible-jedec-spi-nor