### PR TITLE
dts: overlay: Define SRAM as ITCM instead of HRMEM

### DIFF
--- a/app.overlay
+++ b/app.overlay
@@ -4,9 +4,13 @@
 /delete-node/ &hrmem;
 
 / {
+	chosen {
+		zephyr,sram = &itcm;
+	};
+
 	soc {
-		hrmem: memory@0 {
-			compatible = "sc,hrmem";
+		itcm: memory@0 {
+			compatible = "arm,itcm";
 			reg = <0x00000000 DT_SIZE_K(32)>;
 		};
 


### PR DESCRIPTION
In the bootloader, `0x00000000` to `0x00007FFF` is ITCM region, not HRMEM.